### PR TITLE
PODS-2641: accessibilty in the scheme listing page link

### DIFF
--- a/app/views/components/scheme_list.scala.html
+++ b/app/views/components/scheme_list.scala.html
@@ -79,14 +79,10 @@
     @for((scheme, index) <- schemes.zipWithIndex) {
         <div class="row-group grid-row">
             <div class="column-two-sixths table-column scheme-name">
-                <span aria-hidden="true">
-                    @Link.toInternalPage(
-                        id=Some(s"${schemeNameId(index)}"),
-                        url=controllers.routes.SchemeDetailsController.onPageLoad(scheme.referenceNumber).url,
-                        value=Some(scheme.name)
-                    ).toHtml
-                </span>
-                <span class="visually-hidden">@messages("messages__listSchemes__schemeName__screen_reader", scheme.name)</span>
+                <a id="@{schemeNameId(index)}" href="@{controllers.routes.SchemeDetailsController.onPageLoad(scheme.referenceNumber).url}" target="_self" data-sso="false">
+                    <span aria-hidden="true">@{scheme.name}</span>
+                    <span class="visually-hidden">@messages("messages__listSchemes__schemeName__screen_reader", scheme.name)</span>
+                </a>
             </div>
 
                 <div class="column-two-sixths table-column scheme-name">

--- a/test/views/ListSchemesViewSpec.scala
+++ b/test/views/ListSchemesViewSpec.scala
@@ -60,7 +60,7 @@ class ListSchemesViewSpec extends ViewSpecBase with ViewBehaviours {
         val actual = asDocument(view(config, fullList).apply())
 
         actual must haveLinkWithUrlAndContent(s"schemeName-$index",
-          controllers.routes.SchemeDetailsController.onPageLoad(s"reference-number-$index").url, s"scheme-name-$index")
+          controllers.routes.SchemeDetailsController.onPageLoad(s"reference-number-$index").url, s"scheme-name-$index The scheme name is: scheme-name-$index")
       }
     }
 


### PR DESCRIPTION
Accessibility 
we have to ensure that aria-hidden elements do not contain focusable elements.
This needs to get fixed in Your Pension schemes page which is having scheme Link for this we have used CYA page.